### PR TITLE
Link known implementations

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,3 +27,9 @@ Work is underway to create the tools software authors and consumers need to
 handle VEX metadata. The current flagship project is
 [`vexctl`](https://github.com/openvex/vexctl), a CLI to create, merge and
 attest VEX documents.
+
+The project has a growing ecosystem with known implementations in:
+
+* Go (original): https://github.com/openvex/go-vex
+* .NET: [NuGet](https://www.nuget.org/packages/OpenVEX/) [GitHub](https://github.com/JamieMagee/openvex.net)
+* Rust: https://docs.rs/openvex/latest/openvex/


### PR DESCRIPTION
This PR links the known openvex implementations to the org's readme

/cc @rnjudge @luhring @cpanato

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>