### PR TITLE
docs: list Vexcalibur Python implementation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -32,4 +32,5 @@ The project has a growing ecosystem with known implementations in:
 
 * Go (original): https://github.com/openvex/go-vex
 * .NET: [NuGet](https://www.nuget.org/packages/OpenVEX/) [GitHub](https://github.com/JamieMagee/openvex.net)
+* Python: [Vexcalibur](https://github.com/vexcalibur-dev/vexcalibur) ([PyPI](https://pypi.org/project/vexcalibur/))
 * Rust: https://docs.rs/openvex/latest/openvex/


### PR DESCRIPTION
Vexcalibur emits OpenVEX 0.2.0 natively from CycloneDX SBOMs and local findings.

Evidence:

- [current v0.3.0 release](https://github.com/vexcalibur-dev/vexcalibur/releases/tag/v0.3.0)
- [OpenVEX output contract](https://vexcalibur-dev.github.io/vexcalibur/reference/openvex-output.html)
- CI validates the official schema and interoperability with `go-vex` v0.2.8, including the installed release wheel
- [current PyPI package](https://pypi.org/project/vexcalibur/0.3.0/)

This adds it to the organization profile as a known Python implementation. If the implementation list on the [OpenSSF OpenVEX project page](https://openssf.org/projects/openvex/) is maintained separately, we would also appreciate guidance or a mirror there.